### PR TITLE
Add support for encoding.TextUnmarshaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Set some parameters in [AWS Parameter Store](https://docs.aws.amazon.com/systems
 
 | Name                         | Value                     | Type         | Key ID        |
 | ---------------------------- | --------------------      | ------------ | ------------- |
-| /exmaple_service/prod/debug  | false                     | String       | -             |
-| /exmaple_service/prod/port   | 8080                      | String       | -             |
-| /exmaple_service/prod/user   | Ian                       | String       | -             |
-| /exmaple_service/prod/rate   | 0.5                       | String       | -             |
-| /exmaple_service/prod/secret | zOcZkAGB6aEjN7SAoVBT      | SecureString | alias/aws/ssm |
-| /exmaple_service/prod/ts     | 2020-04-14T21:26:00+02:00 | String       | -             |
+| /example_service/prod/debug  | false                     | String       | -             |
+| /example_service/prod/port   | 8080                      | String       | -             |
+| /example_service/prod/user   | Ian                       | String       | -             |
+| /example_service/prod/rate   | 0.5                       | String       | -             |
+| /example_service/prod/secret | zOcZkAGB6aEjN7SAoVBT      | SecureString | alias/aws/ssm |
+| /example_service/prod/ts     | 2020-04-14T21:26:00+02:00 | String       | -             |
         
 Write some code:
 
@@ -37,12 +37,13 @@ import (
 )
 
 type Config struct {
-    Debug  bool          `smm:"debug" default:"true"`
-    Port   int           `smm:"port"`
-    User   string        `smm:"user"`
-    Rate   float32       `smm:"rate"`
-    Secret string        `smm:"secret" required:"true"`
-    Timestamp time.Time  `smm:"ts" required:"true"`
+    Debug     bool       `smm:"debug" default:"true"`
+    Port      int        `smm:"port"`
+    User      string     `smm:"user"`
+    Rate      float32    `smm:"rate"`
+    Secret    string     `smm:"secret" required:"true"`
+    Timestamp time.Time  `smm:"ts"`
+    AltIp     *net.IP    `smm:"alt_ip"`
 }
 
 func main() {
@@ -52,8 +53,8 @@ func main() {
         log.Fatal(err.Error())
     }
     
-    format := "Debug: %v\nPort: %d\nUser: %s\nRate: %f\nSecret: %s\nTimestamp: %s\n"
-    _, err = fmt.Printf(format, c.Debug, c.Port, c.User, c.Rate, c.Secret, c.Timestamp)
+    format := "Debug: %v\nPort: %d\nUser: %s\nRate: %f\nSecret: %s\nTimestamp: %s\nAltIp: %v\n"
+    _, err = fmt.Printf(format, c.Debug, c.Port, c.User, c.Rate, c.Secret, c.Timestamp, c.AltIp)
     if err != nil {
         log.Fatal(err.Error())
     }
@@ -69,6 +70,7 @@ User: Ian
 Rate: 0.500000
 Secret: zOcZkAGB6aEjN7SAoVBT
 Timestamp: 2020-04-14 21:26:00 +0200 +0200
+AltIp: <nil>
 ```
 
 [Additional examples](https://godoc.org/github.com/ianlopshire/go-ssm-config#pkg-examples) can be found in godoc.
@@ -106,7 +108,7 @@ ssmconfig supports these struct field types:
 * float32, float64
 * encoding.TextUnmarshaler
 
-More supported types may be added in the future.
+More supported types may be added in the future. Field types that implement the `encoding.TextUnmarshaler` interface can be used directly or as a pointer.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ AWS Lambda functions. It should be suitable for additional applications.
 
 Set some parameters in [AWS Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html):
 
-| Name                         | Value                | Type         | Key ID        |
-| ---------------------------- | -------------------- | ------------ | ------------- |
-| /exmaple_service/prod/debug  | false                | String       | -             |
-| /exmaple_service/prod/port   | 8080                 | String       | -             |
-| /exmaple_service/prod/user   | Ian                  | String       | -             |
-| /exmaple_service/prod/rate   | 0.5                  | String       | -             |
-| /exmaple_service/prod/secret | zOcZkAGB6aEjN7SAoVBT | SecureString | alias/aws/ssm |
+| Name                         | Value                     | Type         | Key ID        |
+| ---------------------------- | --------------------      | ------------ | ------------- |
+| /exmaple_service/prod/debug  | false                     | String       | -             |
+| /exmaple_service/prod/port   | 8080                      | String       | -             |
+| /exmaple_service/prod/user   | Ian                       | String       | -             |
+| /exmaple_service/prod/rate   | 0.5                       | String       | -             |
+| /exmaple_service/prod/secret | zOcZkAGB6aEjN7SAoVBT      | SecureString | alias/aws/ssm |
+| /exmaple_service/prod/ts     | 2020-04-14T21:26:00+02:00 | String       | -             |
         
 Write some code:
 
@@ -36,11 +37,12 @@ import (
 )
 
 type Config struct {
-    Debug  bool    `smm:"debug" default:"true"`
-    Port   int     `smm:"port"`
-    User   string  `smm:"user"`
-    Rate   float32 `smm:"rate"`
-    Secret string  `smm:"secret" required:"true"`
+    Debug  bool          `smm:"debug" default:"true"`
+    Port   int           `smm:"port"`
+    User   string        `smm:"user"`
+    Rate   float32       `smm:"rate"`
+    Secret string        `smm:"secret" required:"true"`
+    Timestamp time.Time  `smm:"ts" required:"true"`
 }
 
 func main() {
@@ -50,8 +52,8 @@ func main() {
         log.Fatal(err.Error())
     }
     
-    format := "Debug: %v\nPort: %d\nUser: %s\nRate: %f\nSecret: %s\n"
-    _, err = fmt.Printf(format, c.Debug, c.Port, c.User, c.Rate, c.Secret)
+    format := "Debug: %v\nPort: %d\nUser: %s\nRate: %f\nSecret: %s\nTimestamp: %s\n"
+    _, err = fmt.Printf(format, c.Debug, c.Port, c.User, c.Rate, c.Secret, c.Timestamp)
     if err != nil {
         log.Fatal(err.Error())
     }
@@ -66,6 +68,7 @@ Port: 8080
 User: Ian
 Rate: 0.500000
 Secret: zOcZkAGB6aEjN7SAoVBT
+Timestamp: 2020-04-14 21:26:00 +0200 +0200
 ```
 
 [Additional examples](https://godoc.org/github.com/ianlopshire/go-ssm-config#pkg-examples) can be found in godoc.
@@ -101,6 +104,7 @@ ssmconfig supports these struct field types:
 * int, int8, int16, int32, int64
 * bool
 * float32, float64
+* encoding.TextUnmarshaler
 
 More supported types may be added in the future.
 

--- a/ssmconfig.go
+++ b/ssmconfig.go
@@ -64,8 +64,7 @@ func (p *Provider) Process(configPath string, c interface{}) error {
 		return errors.New("ssmconfig: c must be a pointer to a struct")
 	}
 
-	t := v.Type()
-	spec := buildStructSpec(configPath, t)
+	spec := buildStructSpec(configPath, v.Type())
 
 	params, invalidPrams, err := p.getParameters(spec)
 	if err != nil {
@@ -90,9 +89,9 @@ func (p *Provider) Process(configPath string, c interface{}) error {
 			continue
 		}
 
-		valueField := v.Field(i)
-		if err = setValue(valueField, value); err != nil {
-			return errors.Wrapf(err, "ssmconfig: error setting field %s", v.Type().Name())
+		err = setValue(v.Field(i), value)
+		if err != nil {
+			return errors.Wrapf(err, "ssmconfig: error setting field %s", v.Type().Field(i).Name)
 		}
 	}
 

--- a/ssmconfig.go
+++ b/ssmconfig.go
@@ -34,8 +34,6 @@ type Provider struct {
 	SSM ssmiface.SSMAPI
 }
 
-const unmarshalTextMethod = "UnmarshalText"
-
 var textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
 
 // Process loads config values from smm (parameter store) into c. Encrypted parameters

--- a/ssmconfig.go
+++ b/ssmconfig.go
@@ -142,6 +142,7 @@ func (p *Provider) getParameters(spec structSpec) (params map[string]string, inv
 	return params, invalidParams, nil
 }
 
+// Checks whether the value implements the TextUnmarshaler interface.
 func isTextUnmarshaler(f reflect.StructField) bool {
 	return reflect.PtrTo(f.Type).Implements(textUnmarshalerType)
 }

--- a/ssmconfig.go
+++ b/ssmconfig.go
@@ -90,16 +90,16 @@ func (p *Provider) Process(configPath string, c interface{}) error {
 			continue
 		}
 
-		field := v.Field(i)
-		structField := t.Field(i)
+		valueField := v.Field(i)
+		typeField := t.Field(i)
 		var err error
-		if isTextUnmarshaler(structField) {
-			err = unmarshalText(structField, field, value)
+		if isTextUnmarshaler(typeField) {
+			err = unmarshalText(typeField, valueField, value)
 		} else {
-			err = setValue(field, value)
+			err = setValue(valueField, value)
 		}
 		if err != nil {
-			return errors.Wrapf(err, "ssmconfig: error setting field %s", v.Type().Field(i).Name)
+			return errors.Wrapf(err, "ssmconfig: error setting field %s", typeField.Name)
 		}
 	}
 

--- a/ssmconfig_test.go
+++ b/ssmconfig_test.go
@@ -1,10 +1,10 @@
 package ssmconfig_test
 
 import (
-	"encoding/hex"
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -19,20 +19,6 @@ type mockSSMClient struct {
 	err             error
 }
 
-type Hex struct {
-	V string
-}
-
-func (h *Hex) UnmarshalText(val []byte) error {
-	dst := make([]byte, hex.DecodedLen(len(val)))
-	n, err := hex.Decode(dst, val)
-	if err != nil {
-		return err
-	}
-	h.V = string(dst[:n])
-	return nil
-}
-
 func (c *mockSSMClient) GetParameters(input *ssm.GetParametersInput) (*ssm.GetParametersOutput, error) {
 	c.calledWithInput = input
 	if c.err != nil {
@@ -44,18 +30,18 @@ func (c *mockSSMClient) GetParameters(input *ssm.GetParametersInput) (*ssm.GetPa
 func TestProvider_Process(t *testing.T) {
 	t.Run("base case", func(t *testing.T) {
 		var s struct {
-			S1      string  `ssm:"/strings/s1"`
-			S2      string  `ssm:"/strings/s2" default:"string2"`
-			I1      int     `ssm:"/int/i1"`
-			I2      int     `ssm:"/int/i2" default:"42"`
-			B1      bool    `ssm:"/bool/b1"`
-			B2      bool    `ssm:"/bool/b2" default:"false"`
-			F321    float32 `ssm:"/float32/f321"`
-			F322    float32 `ssm:"/float32/f322" default:"42.42"`
-			F641    float64 `ssm:"/float64/f641"`
-			F642    float64 `ssm:"/float64/f642" default:"42.42"`
-			H1      *Hex    `ssm:"/hex/hex1"`
-			H2      *Hex    `ssm:"/hex/hex2" default:"737472696e6731"`
+			S1      string    `ssm:"/strings/s1"`
+			S2      string    `ssm:"/strings/s2" default:"string2"`
+			I1      int       `ssm:"/int/i1"`
+			I2      int       `ssm:"/int/i2" default:"42"`
+			B1      bool      `ssm:"/bool/b1"`
+			B2      bool      `ssm:"/bool/b2" default:"false"`
+			F321    float32   `ssm:"/float32/f321"`
+			F322    float32   `ssm:"/float32/f322" default:"42.42"`
+			F641    float64   `ssm:"/float64/f641"`
+			F642    float64   `ssm:"/float64/f642" default:"42.42"`
+			TU1     time.Time `ssm:"/text_unmarshaler/time1"`
+			TU2     time.Time `ssm:"/text_unmarshaler/time2" default:"2020-04-14T21:26:00+02:00"`
 			Invalid string
 		}
 
@@ -83,8 +69,8 @@ func TestProvider_Process(t *testing.T) {
 						Value: aws.String("42.42"),
 					},
 					{
-						Name:  aws.String("/base/hex/hex1"),
-						Value: aws.String("737472696e6731"),
+						Name:  aws.String("/base/text_unmarshaler/time1"),
+						Value: aws.String("2020-04-14T21:26:00+02:00"),
 					},
 				},
 			},
@@ -115,8 +101,8 @@ func TestProvider_Process(t *testing.T) {
 			"/base/float32/f322",
 			"/base/float64/f641",
 			"/base/float64/f642",
-			"/base/hex/hex1",
-			"/base/hex/hex2",
+			"/base/text_unmarshaler/time1",
+			"/base/text_unmarshaler/time2",
 		}
 
 		if !reflect.DeepEqual(names, expectedNames) {
@@ -153,11 +139,12 @@ func TestProvider_Process(t *testing.T) {
 		if s.F642 != 42.42 {
 			t.Errorf("Process() F642 unexpected value: want %f, have %f", 42.42, s.F642)
 		}
-		if s.H1.V != "string1" {
-			t.Errorf("Process() H1 unexpected value: want %s, have %s", "string1", s.H1.V)
+		tm, _ := time.Parse(time.RFC3339, "2020-04-14T21:26:00+02:00")
+		if !s.TU1.Equal(tm) {
+			t.Errorf("Process() TU1 unexpected value: want %v, have %v", tm, s.TU1)
 		}
-		if s.H2.V != "string1" {
-			t.Errorf("Process() H2 unexpected value: want %s, have %s", "string1", s.H2.V)
+		if !s.TU2.Equal(tm) {
+			t.Errorf("Process() TU2 unexpected value: want %v, have %v", tm, s.TU2)
 		}
 		if s.Invalid != "" {
 			t.Errorf("Process() Missing unexpected value: want %q, have %q", "", s.Invalid)
@@ -204,6 +191,15 @@ func TestProvider_Process(t *testing.T) {
 			configPath: "/base/",
 			c: &struct {
 				B1 bool `ssm:"/bool/b1" default:"notABool"`
+			}{},
+			client:    &mockSSMClient{},
+			shouldErr: true,
+		},
+		{
+			name:       "invalid unmarshal text",
+			configPath: "/base/",
+			c: &struct {
+				B1 bool `ssm:"/text_unmarshaler/time1" default:"notATime"`
 			}{},
 			client:    &mockSSMClient{},
 			shouldErr: true,

--- a/ssmconfig_test.go
+++ b/ssmconfig_test.go
@@ -215,7 +215,7 @@ func TestProvider_Process(t *testing.T) {
 			name:       "invalid unmarshal text",
 			configPath: "/base/",
 			c: &struct {
-				TU1 bool `ssm:"/text_unmarshaler/time1" default:"notATime"`
+				TU1 time.Time `ssm:"/text_unmarshaler/time1" default:"notATime"`
 			}{},
 			client:    &mockSSMClient{},
 			shouldErr: true,
@@ -224,7 +224,7 @@ func TestProvider_Process(t *testing.T) {
 			name:       "invalid unmarshal text",
 			configPath: "/base/",
 			c: &struct {
-				TU3 bool `ssm:"/text_unmarshaler/ipv41" default:"notAnIP"`
+				TU3 net.IP `ssm:"/text_unmarshaler/ipv41" default:"notAnIP"`
 			}{},
 			client:    &mockSSMClient{},
 			shouldErr: true,

--- a/ssmconfig_test.go
+++ b/ssmconfig_test.go
@@ -43,8 +43,10 @@ func TestProvider_Process(t *testing.T) {
 			F642    float64   `ssm:"/float64/f642" default:"42.42"`
 			TU1     time.Time `ssm:"/text_unmarshaler/time1"`
 			TU2     time.Time `ssm:"/text_unmarshaler/time2" default:"2020-04-14T21:26:00+02:00"`
-			TU3     net.IP    `ssm:"/text_unmarshaler/ipv41"`
-			TU4     net.IP    `ssm:"/text_unmarshaler/ipv42" default:"127.0.0.1"`
+			TU3     time.Time `ssm:"/text_unmarshaler/time3"`
+			TUP1    *net.IP   `ssm:"/text_unmarshaler/ipv41"`
+			TUP2    *net.IP   `ssm:"/text_unmarshaler/ipv42" default:"127.0.0.1"`
+			TUP3    *net.IP   `ssm:"/text_unmarshaler/ipv43"`
 			Invalid string
 		}
 
@@ -110,8 +112,10 @@ func TestProvider_Process(t *testing.T) {
 			"/base/float64/f642",
 			"/base/text_unmarshaler/time1",
 			"/base/text_unmarshaler/time2",
+			"/base/text_unmarshaler/time3",
 			"/base/text_unmarshaler/ipv41",
 			"/base/text_unmarshaler/ipv42",
+			"/base/text_unmarshaler/ipv43",
 		}
 
 		if !reflect.DeepEqual(names, expectedNames) {
@@ -155,12 +159,18 @@ func TestProvider_Process(t *testing.T) {
 		if !s.TU2.Equal(tm) {
 			t.Errorf("Process() TU2 unexpected value: want %v, have %v", tm, s.TU2)
 		}
-		ip := net.ParseIP("127.0.0.1")
-		if !s.TU3.Equal(ip) {
-			t.Errorf("Process() TU1 unexpected value: want %v, have %v", ip, s.TU3)
+		if !s.TU3.Equal(time.Time{}) {
+			t.Errorf("Process() TU3 unexpected value: want %v, have %v", time.Time{}, s.TU3)
 		}
-		if !s.TU4.Equal(ip) {
-			t.Errorf("Process() TU2 unexpected value: want %v, have %v", ip, s.TU4)
+		ip := net.ParseIP("127.0.0.1")
+		if !s.TUP1.Equal(ip) {
+			t.Errorf("Process() TUP1 unexpected value: want %v, have %v", ip, s.TUP1)
+		}
+		if !s.TUP2.Equal(ip) {
+			t.Errorf("Process() TUP2 unexpected value: want %v, have %v", ip, s.TUP2)
+		}
+		if s.TUP3 != nil {
+			t.Errorf("Process() TUP3 unexpected value: want %v, have %v", nil, s.TUP3)
 		}
 		if s.Invalid != "" {
 			t.Errorf("Process() Missing unexpected value: want %q, have %q", "", s.Invalid)
@@ -224,7 +234,7 @@ func TestProvider_Process(t *testing.T) {
 			name:       "invalid unmarshal text",
 			configPath: "/base/",
 			c: &struct {
-				TU3 net.IP `ssm:"/text_unmarshaler/ipv41" default:"notAnIP"`
+				TUP1 net.IP `ssm:"/text_unmarshaler/ipv41" default:"notAnIP"`
 			}{},
 			client:    &mockSSMClient{},
 			shouldErr: true,


### PR DESCRIPTION
I thought I would give your request a chance. Adding types that implement the `encoding.TextUnmarshaler` interface should work now.

closes #1 