### PR TITLE
fix: ignore fields that don't have an ssm tag

### DIFF
--- a/ssmconfig.go
+++ b/ssmconfig.go
@@ -67,7 +67,7 @@ func (p *Provider) Process(configPath string, c interface{}) error {
 	}
 
 	for i, field := range spec {
-		if field.name == "" && field.defaultValue == "" {
+		if field.name == "" {
 			continue
 		}
 

--- a/ssmconfig_test.go
+++ b/ssmconfig_test.go
@@ -39,8 +39,10 @@ func TestProvider_Process(t *testing.T) {
 			F322    float32 `ssm:"/float32/f322" default:"42.42"`
 			F641    float64 `ssm:"/float64/f641"`
 			F642    float64 `ssm:"/float64/f642" default:"42.42"`
+			NoSSM   string  `default:"ignored"`
 			Invalid string
 		}
+		s.NoSSM = "pre"
 
 		mc := &mockSSMClient{
 			output: &ssm.GetParametersOutput{
@@ -129,6 +131,9 @@ func TestProvider_Process(t *testing.T) {
 		}
 		if s.F642 != 42.42 {
 			t.Errorf("Process() F642 unexpected value: want %f, have %f", 42.42, s.F642)
+		}
+		if s.NoSSM != "pre" {
+			t.Errorf("Process() NoSSM unexpected value: want %q, have %q", "pre", s.NoSSM)
 		}
 		if s.Invalid != "" {
 			t.Errorf("Process() Missing unexpected value: want %q, have %q", "", s.Invalid)


### PR DESCRIPTION
I process my struct with kelseyhightower/envconfig before passing it to go-ssm-config. The problem with that is any field that has a `default` tag but no `ssm` is overwritten with the specified default value. I would like go-ssm-config to skip any field that doesn't have an `ssm` tag so the value obtained from envconfig is retained. This PR fixes this behavior as documented in the README:

> If the `ssm` tag is missing ssmconfig will ignore the struct field.
